### PR TITLE
Fix asset URLs for GitHub Pages deployment

### DIFF
--- a/web/client/index.html
+++ b/web/client/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Defense for Very Pixi - a polished web remake of the DfVP tower defense game built with PixiJS." />
     <title>Defense for Very Pixi</title>
-    <link rel="icon" type="image/png" href="/assets/player0.png" />
+    <link rel="icon" type="image/png" href="./assets/player0.png" />
   </head>
   <body>
     <noscript>You need JavaScript enabled to play Defense for Very Pixi.</noscript>

--- a/web/client/src/app.ts
+++ b/web/client/src/app.ts
@@ -266,13 +266,17 @@ export class DfvpGame {
   }
 
   private async loadAssets(): Promise<void> {
+    const assetBasePath = import.meta.env.BASE_URL.endsWith('/')
+      ? import.meta.env.BASE_URL
+      : `${import.meta.env.BASE_URL}/`;
+
     const manifest = {
       bundles: [
         {
           name: 'main',
           assets: ASSET_FILES.map((name) => ({
             alias: name.replace(/\.png$/i, ''),
-            src: `/assets/${name}`,
+            src: `${assetBasePath}assets/${name}`,
           })),
         },
       ],


### PR DESCRIPTION
## Summary
- update the favicon reference to use a relative asset path that works on GitHub Pages
- resolve runtime asset loading through Vite's base URL so bundles load under subdirectories

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e669c7f984832e8ab125f37f359c1e